### PR TITLE
Create contract export step

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "flatten": "rm -rf ./build/flattened && ./scripts/flatten.sh",
     "prebuild": "yarn flatten",
     "build": "truffle compile",
+    "postbuild": "rm -rf ./build/exports && ./scripts/export.sh",
     "format": "prettier --write --loglevel warn \"./{,migrations,test}/*.{js,json,md}\"",
     "lint": "yarn run lint:js && yarn run lint:sol",
     "lint:js": "eslint .",

--- a/scripts/export.sh
+++ b/scripts/export.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail
+command -v shellcheck > /dev/null && shellcheck "$0"
+
+artifacts_dir="build/contracts"
+exports_dir="build/exports"
+mkdir -p "$exports_dir"
+
+# Use source folder to find top leven contracts in artifacts
+for inpath in contracts/*.sol; do
+  contractName=$(basename "$inpath" .sol)
+
+  compilationArtifact="$artifacts_dir/$contractName.json"
+  exportFile="$exports_dir/$contractName.json"
+
+  contractNameFromArtifact=$(jq -r '.contractName' < "$compilationArtifact")
+  if [[ "$contractName" != "$contractNameFromArtifact" ]]; then
+    echo "Contract name from filename ('$contractName') does not match contract name from artifact ('$contractNameFromArtifact')"
+    exit 1
+  fi
+
+  echo "Exporting $compilationArtifact into $exportFile ..."
+
+  # Copy some important or interesting fields that do not include developer machine information
+  # web3x-codegen only needs abi and bytecode (https://github.com/xf00f/web3x/blob/master/src/codegen/sources/source-truffle.ts)
+  jq '{ contractName, abi, bytecode, compiler, userdoc }' \
+    < "$compilationArtifact" \
+    > "$exportFile"
+done

--- a/scripts/export.sh
+++ b/scripts/export.sh
@@ -6,7 +6,7 @@ artifacts_dir="build/contracts"
 exports_dir="build/exports"
 mkdir -p "$exports_dir"
 
-# Use source folder to find top leven contracts in artifacts
+# Use source folder to find top level contracts in artifacts
 for inpath in contracts/*.sol; do
   contractName=$(basename "$inpath" .sol)
 


### PR DESCRIPTION
A contract export is a truffle artifact JSON with the fields `contractName`, `abi`, `bytecode`, `compiler`, `userdoc` only. This reduces the file size and removes fields that include dev machine paths. Those exports can be copied into IOV-Core, where they can be used to generate the typescript interface.