### PR TITLE
Add atomic swap contract for ERC20 tokens

### DIFF
--- a/contracts/AtomicSwapERC20.sol
+++ b/contracts/AtomicSwapERC20.sol
@@ -1,0 +1,128 @@
+pragma solidity ^0.5.2;
+
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
+
+contract AtomicSwapERC20 {
+    enum State {
+        NON_EXISTENT,
+        OPEN,
+        CLAIMED,
+        ABORTED
+    }
+
+    struct Swap {
+        State state;
+        address sender;
+        address recipient;
+        bytes32 hash;
+        uint256 amount;
+        uint256 timeout;
+        bytes32 preimage;
+        address erc20ContractAddress;
+    }
+
+    mapping (bytes32 => Swap) private swaps;
+
+    event Opened(bytes32 id, address recipient, bytes32 hash, address erc20ContractAddress);
+    event Claimed(bytes32 id, bytes32 preimage);
+    event Aborted(bytes32 id);
+
+    modifier onlyExistentSwaps(bytes32 id) {
+        require(swaps[id].state != State.NON_EXISTENT, "No swap found for the given ID");
+        _;
+    }
+
+    modifier onlyNonExistentSwaps(bytes32 id) {
+        require(swaps[id].state == State.NON_EXISTENT, "Swap ID already exists");
+        _;
+    }
+
+    modifier onlyOpenSwaps(bytes32 id) {
+        require(swaps[id].state == State.OPEN, "No open swap found for the given ID");
+        _;
+    }
+
+    modifier onlyWithValidPreimage(bytes32 id, bytes32 preimage) {
+        require(swaps[id].hash == sha256(abi.encodePacked(preimage)), "Invalid preimage for swap hash");
+        _;
+    }
+
+    modifier onlyAbortableSwaps(bytes32 id) {
+        require(block.number >= swaps[id].timeout, "Swap timeout has not been reached");
+        _;
+    }
+
+    function open(
+        bytes32 id,
+        address recipient,
+        bytes32 hash,
+        uint256 timeout,
+        address erc20ContractAddress,
+        uint256 amount
+    ) external onlyNonExistentSwaps(id) {
+        ERC20 erc20Contract = ERC20(erc20ContractAddress);
+        erc20Contract.transferFrom(msg.sender, address(this), amount);
+
+        swaps[id] = Swap({
+            state: State.OPEN,
+            sender: msg.sender,
+            recipient: recipient,
+            hash: hash,
+            amount: amount,
+            timeout: timeout,
+            preimage: bytes32(0),
+            erc20ContractAddress: erc20ContractAddress
+        });
+
+        emit Opened(id, recipient, hash, erc20ContractAddress);
+    }
+
+    function claim(
+        bytes32 id,
+        bytes32 preimage
+    ) external onlyOpenSwaps(id) onlyWithValidPreimage(id, preimage) {
+        swaps[id].state = State.CLAIMED;
+        swaps[id].preimage = preimage;
+
+        Swap memory swap = swaps[id];
+        ERC20 erc20Contract = ERC20(swap.erc20ContractAddress);
+        erc20Contract.transfer(swap.recipient, swap.amount);
+
+        emit Claimed(id, preimage);
+    }
+
+    function abort(
+        bytes32 id
+    ) external onlyOpenSwaps(id) onlyAbortableSwaps(id) {
+        swaps[id].state = State.ABORTED;
+
+        Swap memory swap = swaps[id];
+        ERC20 erc20Contract = ERC20(swap.erc20ContractAddress);
+        erc20Contract.transfer(swap.sender, swap.amount);
+
+        emit Aborted(id);
+    }
+
+    function get(
+        bytes32 id
+    ) external view onlyExistentSwaps(id) returns (
+        address sender,
+        address recipient,
+        bytes32 hash,
+        uint256 timeout,
+        uint256 amount,
+        bytes32 preimage,
+        address erc20ContractAddress
+    ) {
+        Swap memory swap = swaps[id];
+        return (
+            swap.sender,
+            swap.recipient,
+            swap.hash,
+            swap.timeout,
+            swap.amount,
+            swap.preimage,
+            swap.erc20ContractAddress
+        );
+    }
+}

--- a/contracts/AtomicSwapERC20.sol
+++ b/contracts/AtomicSwapERC20.sol
@@ -61,7 +61,7 @@ contract AtomicSwapERC20 {
         uint256 amount
     ) external onlyNonExistentSwaps(id) {
         ERC20 erc20Contract = ERC20(erc20ContractAddress);
-        erc20Contract.transferFrom(msg.sender, address(this), amount);
+        require(erc20Contract.transferFrom(msg.sender, address(this), amount), "ERC20 token transfer was unsuccessful");
 
         swaps[id] = Swap({
             state: State.OPEN,
@@ -86,7 +86,7 @@ contract AtomicSwapERC20 {
 
         Swap memory swap = swaps[id];
         ERC20 erc20Contract = ERC20(swap.erc20ContractAddress);
-        erc20Contract.transfer(swap.recipient, swap.amount);
+        require(erc20Contract.transfer(swap.recipient, swap.amount), "ERC20 token transfer was unsuccessful");
 
         emit Claimed(id, preimage);
     }
@@ -98,7 +98,7 @@ contract AtomicSwapERC20 {
 
         Swap memory swap = swaps[id];
         ERC20 erc20Contract = ERC20(swap.erc20ContractAddress);
-        erc20Contract.transfer(swap.sender, swap.amount);
+        require(erc20Contract.transfer(swap.sender, swap.amount), "ERC20 token transfer was unsuccessful");
 
         emit Aborted(id);
     }

--- a/migrations/5_atomic_swap_erc20.js
+++ b/migrations/5_atomic_swap_erc20.js
@@ -1,0 +1,5 @@
+const AtomicSwapERC20 = artifacts.require("./AtomicSwapERC20.sol");
+
+module.exports = function(deployer) {
+  deployer.deploy(AtomicSwapERC20);
+};

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint:js": "eslint .",
     "lint:js:fix": "eslint --fix .",
     "lint:sol": "solhint \"contracts/**/*.sol\"",
-    "pretest": "yarn flatten",
+    "pretest": "[ -n \"$SKIP_FLATTEN\" ] || yarn flatten",
     "test": "./scripts/test.sh",
     "test:property": "./scripts/echidna.sh",
     "verify": "truffle run verify"

--- a/scripts/ci/main.sh
+++ b/scripts/ci/main.sh
@@ -26,6 +26,8 @@ fold_start "test"
 yarn run test
 fold_end
 
-fold_start "verify"
-yarn run verify --no-progress
-fold_end
+# Requires an authenticated MythX account or risk rate limiting
+# See https://github.com/ConsenSys/truffle-security#configuration
+# fold_start "verify"
+# yarn run verify --no-progress
+# fold_end

--- a/test/AtomicSwapERC20.js
+++ b/test/AtomicSwapERC20.js
@@ -1,0 +1,505 @@
+const BN = require("bn.js");
+const { expect, expectEvent } = require("./setup");
+const { getErc20Balance, makeRandomAddress, makeRandomId, makeTimeout, sleep } = require("./utils");
+
+const atomicSwap = artifacts.require("./AtomicSwapERC20.sol");
+const erc20 = artifacts.require("./AshToken.sol");
+
+contract("AtomicSwapERC20", accounts => {
+  const defaultPreimage = "0x42a990655bffe188c9823a2f914641a32dcbb1b28e8586bd29af291db7dcd4e8";
+  const defaultHash = "0x261c74f7dd1ed6a069e18375ab2bee9afcb1095613f53b07de11829ac66cdfcc";
+  const nullPreimage = "0x0000000000000000000000000000000000000000000000000000000000000000";
+  const defaultAmount = "50000000";
+  const defaultAmountBN = new BN(defaultAmount);
+  const defaultSender = accounts[1];
+  const defaultRecipient = accounts[2];
+
+  let testContract;
+  let erc20Contract;
+
+  before(async () => {
+    testContract = await atomicSwap.deployed();
+    erc20Contract = await erc20.deployed();
+
+    await erc20Contract.mint(defaultSender, "1" + "0".repeat(15));
+    await erc20Contract.mint(defaultRecipient, "1" + "0".repeat(15));
+  });
+
+  describe("open()", () => {
+    beforeEach(async () => {
+      await erc20Contract.approve(testContract.address, defaultAmount, { from: defaultSender });
+    });
+
+    it("accepts tokens", async () => {
+      const id = makeRandomId();
+      const recipient = makeRandomAddress();
+      const timeout = await makeTimeout();
+      const initialBalanceContract = await getErc20Balance(erc20Contract, testContract.address);
+      const initialBalanceSender = await getErc20Balance(erc20Contract, defaultSender);
+
+      await testContract.open(id, recipient, defaultHash, timeout, erc20Contract.address, defaultAmount, {
+        from: defaultSender,
+      });
+
+      await expect(
+        getErc20Balance(erc20Contract, testContract.address),
+      ).eventually.to.be.a.bignumber.that.equals(initialBalanceContract.add(defaultAmountBN));
+      await expect(getErc20Balance(erc20Contract, accounts[1])).eventually.to.be.a.bignumber.that.equals(
+        initialBalanceSender.sub(defaultAmountBN),
+      );
+      await expect(getErc20Balance(erc20Contract, recipient)).eventually.to.be.a.bignumber.that.is.zero;
+    });
+
+    it("emits an Opened event", async () => {
+      const id = makeRandomId();
+      const recipient = makeRandomAddress();
+      const timeout = await makeTimeout();
+      const { tx } = await testContract.open(
+        id,
+        recipient,
+        defaultHash,
+        timeout,
+        erc20Contract.address,
+        defaultAmount,
+        {
+          from: defaultSender,
+        },
+      );
+
+      await expectEvent.inTransaction(tx, atomicSwap, "Opened", {
+        id,
+        recipient,
+        hash: defaultHash,
+        erc20ContractAddress: erc20Contract.address,
+      });
+    });
+
+    it("errors when attempting to open a swap with an existing ID", async () => {
+      const id = makeRandomId();
+
+      {
+        const recipient = makeRandomAddress();
+        const timeout = await makeTimeout();
+        await testContract.open(id, recipient, defaultHash, timeout, erc20Contract.address, defaultAmount, {
+          from: defaultSender,
+        });
+      }
+
+      {
+        const recipient = makeRandomAddress();
+        const timeout = await makeTimeout();
+        await expect(
+          testContract.open(id, recipient, defaultHash, timeout, erc20Contract.address, defaultAmount, {
+            from: defaultSender,
+          }),
+        ).to.be.rejectedWith(/swap id already exists/i);
+      }
+    });
+
+    it("errors when attempting to open a swap from a non-erc20 token", async () => {
+      const id = makeRandomId();
+      const timeout = await makeTimeout();
+      await expect(
+        testContract.open(id, defaultRecipient, defaultHash, timeout, defaultRecipient, defaultAmount, {
+          from: defaultSender,
+        }),
+      ).to.be.rejectedWith(/revert/i);
+    });
+
+    it("errors when attempting to open a swap without enough approval", async () => {
+      const id = makeRandomId();
+      const timeout = await makeTimeout();
+      const tooMuch = "1" + "0".repeat(16);
+      await expect(
+        testContract.open(id, defaultRecipient, defaultHash, timeout, erc20Contract.address, tooMuch, {
+          from: defaultSender,
+        }),
+      ).to.be.rejectedWith(/revert/i);
+    });
+  });
+
+  describe("claim()", () => {
+    beforeEach(async () => {
+      await erc20Contract.approve(testContract.address, defaultAmount, { from: defaultSender });
+    });
+
+    it("disburses tokens to recipient", async () => {
+      const id = makeRandomId();
+      const timeout = await makeTimeout();
+
+      await testContract.open(
+        id,
+        defaultRecipient,
+        defaultHash,
+        timeout,
+        erc20Contract.address,
+        defaultAmount,
+        {
+          from: defaultSender,
+        },
+      );
+      const initialBalanceContract = await getErc20Balance(erc20Contract, testContract.address);
+      const initialBalanceSender = await getErc20Balance(erc20Contract, defaultSender);
+      const initialBalanceRecipient = await getErc20Balance(erc20Contract, defaultRecipient);
+
+      await testContract.claim(id, defaultPreimage, { from: defaultRecipient });
+
+      await expect(
+        getErc20Balance(erc20Contract, testContract.address),
+      ).eventually.to.be.a.bignumber.that.equals(initialBalanceContract.sub(defaultAmountBN));
+      await expect(getErc20Balance(erc20Contract, defaultSender)).eventually.to.be.a.bignumber.that.equals(
+        initialBalanceSender,
+      );
+      await expect(getErc20Balance(erc20Contract, defaultRecipient)).eventually.to.be.a.bignumber.that.equals(
+        initialBalanceRecipient.add(defaultAmountBN),
+      );
+    });
+
+    it("emits a Claimed event", async () => {
+      const id = makeRandomId();
+      const timeout = await makeTimeout();
+
+      await testContract.open(
+        id,
+        defaultRecipient,
+        defaultHash,
+        timeout,
+        erc20Contract.address,
+        defaultAmount,
+        {
+          from: defaultSender,
+        },
+      );
+
+      const { tx } = await testContract.claim(id, defaultPreimage, { from: defaultRecipient });
+
+      await expectEvent.inTransaction(tx, atomicSwap, "Claimed", {
+        id,
+        preimage: defaultPreimage,
+      });
+    });
+
+    it("errors when attempting to claim a non-existent swap", async () => {
+      const id = makeRandomId();
+
+      await expect(testContract.claim(id, defaultPreimage, { from: defaultRecipient })).to.be.rejectedWith(
+        /no open swap found for the given id/i,
+      );
+    });
+
+    it("errors when attempting to claim a swap with incorrect preimage", async () => {
+      const preimage = `0x5${defaultPreimage.slice(3)}`;
+      const id = makeRandomId();
+      const timeout = await makeTimeout();
+
+      await testContract.open(
+        id,
+        defaultRecipient,
+        defaultHash,
+        timeout,
+        erc20Contract.address,
+        defaultAmount,
+        {
+          from: defaultSender,
+        },
+      );
+
+      await expect(testContract.claim(id, preimage, { from: defaultRecipient })).to.be.rejectedWith(
+        /invalid preimage for swap hash/i,
+      );
+    });
+
+    it("errors when attempting to claim a swap with a preimage which is too short", async () => {
+      // 31 bytes
+      const preimage = "0xa990655bffe188c9823a2f914641a32dcbb1b28e8586bd29af291db7dcd4e8";
+      const hash = "0xe4632a45b8e39230777acdb63647b9513d5686bb4d9cb7a3be2f89664eb0fd32";
+      const id = makeRandomId();
+      const timeout = await makeTimeout();
+
+      await testContract.open(id, defaultRecipient, hash, timeout, erc20Contract.address, defaultAmount, {
+        from: defaultSender,
+      });
+
+      await expect(testContract.claim(id, preimage, { from: defaultRecipient })).to.be.rejectedWith(
+        /invalid preimage for swap hash/i,
+      );
+    });
+
+    it("errors when attempting to claim a swap with a preimage which is too long", async () => {
+      // 33 bytes
+      const preimage = "0xa990655bffe188c9823a2f914641a32dcbb1b28e8586bd29af291db7dcd4e8";
+      const hash = "0xe4632a45b8e39230777acdb63647b9513d5686bb4d9cb7a3be2f89664eb0fd32";
+      const id = makeRandomId();
+      const timeout = await makeTimeout();
+
+      await testContract.open(id, defaultRecipient, hash, timeout, erc20Contract.address, defaultAmount, {
+        from: defaultSender,
+      });
+
+      await expect(testContract.claim(id, preimage, { from: defaultRecipient })).to.be.rejectedWith(
+        /invalid preimage for swap hash/i,
+      );
+    });
+
+    it("errors when attempting to claim a swap which has already been claimed", async () => {
+      const id = makeRandomId();
+      const timeout = await makeTimeout();
+
+      await testContract.open(
+        id,
+        defaultRecipient,
+        defaultHash,
+        timeout,
+        erc20Contract.address,
+        defaultAmount,
+        {
+          from: defaultSender,
+        },
+      );
+      await testContract.claim(id, defaultPreimage, { from: defaultRecipient });
+
+      await expect(testContract.claim(id, defaultPreimage, { from: defaultRecipient })).to.be.rejectedWith(
+        /no open swap found for the given id/i,
+      );
+    });
+
+    it("errors when attempting to claim a swap which has already been aborted", async () => {
+      const id = makeRandomId();
+      const timeout = await makeTimeout(1);
+
+      await testContract.open(
+        id,
+        defaultRecipient,
+        defaultHash,
+        timeout,
+        erc20Contract.address,
+        defaultAmount,
+        {
+          from: defaultSender,
+        },
+      );
+      await sleep(2);
+      await testContract.abort(id, { from: defaultSender });
+
+      await expect(testContract.claim(id, defaultPreimage, { from: defaultRecipient })).to.be.rejectedWith(
+        /no open swap found for the given id/i,
+      );
+    });
+  });
+
+  describe("abort()", () => {
+    beforeEach(async () => {
+      await erc20Contract.approve(testContract.address, defaultAmount, { from: defaultSender });
+    });
+
+    it("returns tokens to sender", async () => {
+      const id = makeRandomId();
+      const timeout = await makeTimeout(1);
+
+      await testContract.open(
+        id,
+        defaultRecipient,
+        defaultHash,
+        timeout,
+        erc20Contract.address,
+        defaultAmount,
+        {
+          from: defaultSender,
+        },
+      );
+      await sleep(2);
+      const initialBalanceContract = await getErc20Balance(erc20Contract, testContract.address);
+      const initialBalanceSender = await getErc20Balance(erc20Contract, defaultSender);
+      const initialBalanceRecipient = await getErc20Balance(erc20Contract, defaultRecipient);
+
+      await testContract.abort(id, { from: defaultSender });
+
+      await expect(
+        getErc20Balance(erc20Contract, testContract.address),
+      ).eventually.to.be.a.bignumber.that.equals(initialBalanceContract.sub(defaultAmountBN));
+      await expect(getErc20Balance(erc20Contract, defaultSender)).eventually.to.be.a.bignumber.that.equals(
+        initialBalanceSender.add(defaultAmountBN),
+      );
+      await expect(getErc20Balance(erc20Contract, defaultRecipient)).eventually.to.be.a.bignumber.that.equals(
+        initialBalanceRecipient,
+      );
+    });
+
+    it("emits an Aborted event", async () => {
+      const id = makeRandomId();
+      const timeout = await makeTimeout(1);
+
+      await testContract.open(
+        id,
+        defaultRecipient,
+        defaultHash,
+        timeout,
+        erc20Contract.address,
+        defaultAmount,
+        { from: defaultSender },
+      );
+      await sleep(2);
+
+      const { tx } = await testContract.abort(id, { from: defaultSender });
+
+      await expectEvent.inTransaction(tx, atomicSwap, "Aborted", {
+        id,
+      });
+    });
+
+    it("errors when attempting to abort a non-existent swap", async () => {
+      const id = makeRandomId();
+
+      await expect(testContract.abort(id, { from: defaultSender })).to.be.rejectedWith(
+        /no open swap found for the given id/i,
+      );
+    });
+
+    it("errors when attempting to abort before the timeout", async () => {
+      const id = makeRandomId();
+      const timeout = await makeTimeout(1e5);
+
+      await testContract.open(
+        id,
+        defaultRecipient,
+        defaultHash,
+        timeout,
+        erc20Contract.address,
+        defaultAmount,
+        { from: defaultSender },
+      );
+
+      await expect(testContract.abort(id, { from: defaultSender })).to.be.rejectedWith(
+        /swap timeout has not been reached/i,
+      );
+    });
+
+    it("errors when attempting to abort a swap which has already been claimed", async () => {
+      const id = makeRandomId();
+      const timeout = await makeTimeout();
+
+      await testContract.open(
+        id,
+        defaultRecipient,
+        defaultHash,
+        timeout,
+        erc20Contract.address,
+        defaultAmount,
+        { from: defaultSender },
+      );
+      await testContract.claim(id, defaultPreimage, { from: defaultRecipient });
+
+      await expect(testContract.abort(id, { from: defaultSender })).to.be.rejectedWith(
+        /no open swap found for the given id/i,
+      );
+    });
+
+    it("errors when attempting to abort a swap which has already been aborted", async () => {
+      const id = makeRandomId();
+      const timeout = await makeTimeout(1);
+
+      await testContract.open(
+        id,
+        defaultRecipient,
+        defaultHash,
+        timeout,
+        erc20Contract.address,
+        defaultAmount,
+        { from: defaultSender },
+      );
+      await sleep(2);
+      await testContract.abort(id, { from: defaultSender });
+
+      await expect(testContract.abort(id, { from: defaultSender })).to.be.rejectedWith(
+        /no open swap found for the given id/i,
+      );
+    });
+  });
+
+  describe("get()", () => {
+    beforeEach(async () => {
+      await erc20Contract.approve(testContract.address, defaultAmount, { from: defaultSender });
+    });
+
+    it("shows an open swap by id", async () => {
+      const id = makeRandomId();
+      const timeout = await makeTimeout();
+
+      await testContract.open(
+        id,
+        defaultRecipient,
+        defaultHash,
+        timeout,
+        erc20Contract.address,
+        defaultAmount,
+        { from: defaultSender },
+      );
+
+      const result = await testContract.get(id);
+      expect(result.sender).to.equal(defaultSender);
+      expect(result.recipient).to.equal(defaultRecipient);
+      expect(result.hash).to.equal(defaultHash);
+      expect(result.timeout).to.be.a.bignumber.that.equals(new BN(timeout));
+      expect(result.amount).to.be.a.bignumber.that.equals(defaultAmount);
+      expect(result.preimage).to.equal(nullPreimage);
+      expect(result.erc20ContractAddress).to.equal(erc20Contract.address);
+    });
+
+    it("shows a claimed swap by id including preimage", async () => {
+      const id = makeRandomId();
+      const timeout = await makeTimeout();
+
+      await testContract.open(
+        id,
+        defaultRecipient,
+        defaultHash,
+        timeout,
+        erc20Contract.address,
+        defaultAmount,
+        { from: defaultSender },
+      );
+      await testContract.claim(id, defaultPreimage, { from: defaultRecipient });
+
+      const result = await testContract.get(id);
+      expect(result.sender).to.equal(defaultSender);
+      expect(result.recipient).to.equal(defaultRecipient);
+      expect(result.hash).to.equal(defaultHash);
+      expect(result.timeout).to.be.a.bignumber.that.equals(new BN(timeout));
+      expect(result.amount).to.be.a.bignumber.that.equals(defaultAmount);
+      expect(result.preimage).to.equal(defaultPreimage);
+      expect(result.erc20ContractAddress).to.equal(erc20Contract.address);
+    });
+
+    it("shows an aborted swap by id", async () => {
+      const id = makeRandomId();
+      const timeout = await makeTimeout(1);
+
+      await testContract.open(
+        id,
+        defaultRecipient,
+        defaultHash,
+        timeout,
+        erc20Contract.address,
+        defaultAmount,
+        { from: defaultSender },
+      );
+      await sleep(2);
+      await testContract.abort(id, { from: defaultSender });
+
+      const result = await testContract.get(id);
+      expect(result.sender).to.equal(defaultSender);
+      expect(result.recipient).to.equal(defaultRecipient);
+      expect(result.hash).to.equal(defaultHash);
+      expect(result.timeout).to.be.a.bignumber.that.equals(new BN(timeout));
+      expect(result.amount).to.be.a.bignumber.that.equals(defaultAmount);
+      expect(result.preimage).to.equal(nullPreimage);
+      expect(result.erc20ContractAddress).to.equal(erc20Contract.address);
+    });
+
+    it("errors when attempting to view a non-existent swap", async () => {
+      const id = makeRandomId();
+
+      await expect(testContract.get(id)).to.be.rejectedWith(/no swap found for the given id/i);
+    });
+  });
+});

--- a/test/AtomicSwapEther.js
+++ b/test/AtomicSwapEther.js
@@ -1,6 +1,6 @@
 const BN = require("bn.js");
 const { expect, expectEvent } = require("./setup");
-const { getBalance, makeRandomAddress, makeRandomId, makeTimeout, sleep } = require("./utils");
+const { getEthBalance, makeRandomAddress, makeRandomId, makeTimeout, sleep } = require("./utils");
 
 const atomicSwap = artifacts.require("./AtomicSwapEther.sol");
 
@@ -22,21 +22,21 @@ contract("AtomicSwapEther", accounts => {
       const id = makeRandomId();
       const recipient = makeRandomAddress();
       const timeout = await makeTimeout();
-      const initialBalanceContract = await getBalance(testContract.address);
-      const initialBalanceSender = await getBalance(accounts[1]);
+      const initialBalanceContract = await getEthBalance(testContract.address);
+      const initialBalanceSender = await getEthBalance(accounts[1]);
 
       await testContract.open(id, recipient, defaultHash, timeout, {
         from: accounts[1],
         value: defaultAmount,
       });
 
-      await expect(getBalance(testContract.address)).eventually.to.be.a.bignumber.that.equals(
+      await expect(getEthBalance(testContract.address)).eventually.to.be.a.bignumber.that.equals(
         initialBalanceContract.add(defaultAmountBN),
       );
-      await expect(getBalance(accounts[0])).eventually.to.be.a.bignumber.below(
+      await expect(getEthBalance(accounts[0])).eventually.to.be.a.bignumber.below(
         initialBalanceSender.sub(defaultAmountBN),
       );
-      await expect(getBalance(recipient)).eventually.to.be.a.bignumber.that.is.zero;
+      await expect(getEthBalance(recipient)).eventually.to.be.a.bignumber.that.is.zero;
     });
 
     it("emits an Opened event", async () => {
@@ -82,17 +82,17 @@ contract("AtomicSwapEther", accounts => {
         from: sender,
         value: defaultAmount,
       });
-      const initialBalanceContract = await getBalance(testContract.address);
-      const initialBalanceSender = await getBalance(sender);
-      const initialBalanceRecipient = await getBalance(recipient);
+      const initialBalanceContract = await getEthBalance(testContract.address);
+      const initialBalanceSender = await getEthBalance(sender);
+      const initialBalanceRecipient = await getEthBalance(recipient);
 
       await testContract.claim(id, defaultPreimage);
 
-      await expect(getBalance(testContract.address)).eventually.to.be.a.bignumber.that.equals(
+      await expect(getEthBalance(testContract.address)).eventually.to.be.a.bignumber.that.equals(
         initialBalanceContract.sub(defaultAmountBN),
       );
-      await expect(getBalance(sender)).eventually.to.be.a.bignumber.that.equals(initialBalanceSender);
-      await expect(getBalance(recipient)).eventually.to.be.a.bignumber.that.equals(
+      await expect(getEthBalance(sender)).eventually.to.be.a.bignumber.that.equals(initialBalanceSender);
+      await expect(getEthBalance(recipient)).eventually.to.be.a.bignumber.that.equals(
         initialBalanceRecipient.add(defaultAmountBN),
       );
     });
@@ -191,19 +191,21 @@ contract("AtomicSwapEther", accounts => {
         value: defaultAmount,
       });
       await sleep(2);
-      const initialBalanceContract = await getBalance(testContract.address);
-      const initialBalanceSender = await getBalance(sender);
-      const initialBalanceRecipient = await getBalance(recipient);
+      const initialBalanceContract = await getEthBalance(testContract.address);
+      const initialBalanceSender = await getEthBalance(sender);
+      const initialBalanceRecipient = await getEthBalance(recipient);
 
       await testContract.abort(id);
 
-      await expect(getBalance(testContract.address)).eventually.to.be.a.bignumber.that.equals(
+      await expect(getEthBalance(testContract.address)).eventually.to.be.a.bignumber.that.equals(
         initialBalanceContract.sub(defaultAmountBN),
       );
-      await expect(getBalance(sender)).eventually.to.be.a.bignumber.that.equals(
+      await expect(getEthBalance(sender)).eventually.to.be.a.bignumber.that.equals(
         initialBalanceSender.add(defaultAmountBN),
       );
-      await expect(getBalance(recipient)).eventually.to.be.a.bignumber.that.equals(initialBalanceRecipient);
+      await expect(getEthBalance(recipient)).eventually.to.be.a.bignumber.that.equals(
+        initialBalanceRecipient,
+      );
     });
 
     it("emits an Aborted event", async () => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -7,6 +7,10 @@ const { host, port } = networks.test;
 
 const TEST_URL = `http://${host}:${port}`;
 
+async function getErc20Balance(contract, address) {
+  return contract.balanceOf(address);
+}
+
 async function getEthBalance(address) {
   const connection = await EthereumConnection.establish(TEST_URL);
   const account = await connection.getAccount({ address });
@@ -39,6 +43,7 @@ async function sleep(seconds) {
 }
 
 module.exports = {
+  getErc20Balance,
   getEthBalance,
   makeRandomId,
   makeRandomAddress,

--- a/test/utils.js
+++ b/test/utils.js
@@ -7,7 +7,7 @@ const { host, port } = networks.test;
 
 const TEST_URL = `http://${host}:${port}`;
 
-async function getBalance(address) {
+async function getEthBalance(address) {
   const connection = await EthereumConnection.establish(TEST_URL);
   const account = await connection.getAccount({ address });
   connection.disconnect();
@@ -39,7 +39,7 @@ async function sleep(seconds) {
 }
 
 module.exports = {
-  getBalance,
+  getEthBalance,
   makeRandomId,
   makeRandomAddress,
   makeTimeout,

--- a/yarn.lock
+++ b/yarn.lock
@@ -184,9 +184,9 @@
   integrity sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q==
 
 "@types/node@*":
-  version "11.11.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.11.7.tgz#f1c35a906b82adae76ede5ab0d2088e58fa37843"
-  integrity sha512-bHbRcyD6XpXVLg42QYaQCjvDXaCFkvb3WbCIxSDmhGbJYVroxvYzekk9QGg1beeIawfvSLkdZpP0h7jxE4ihnA==
+  version "11.12.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.12.0.tgz#ec5594728811dc2797e42396cfcdf786f2052c12"
+  integrity sha512-Lg00egj78gM+4aE0Erw05cuDbvX9sLJbaaPwwRtdCdAMnIudqrQZ0oZX98Ek0yiSK/A2nubHgJfvII/rTT2Dwg==
 
 "@types/node@^10.12.18", "@types/node@^10.3.2":
   version "10.14.4"
@@ -3787,9 +3787,9 @@ semaphore@>=1.0.1:
   integrity sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA==
 
 semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
-  integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
+  integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
 
 semver@~5.4.1:
   version "5.4.1"
@@ -3936,9 +3936,9 @@ solc@0.5.0:
     yargs "^11.0.0"
 
 solc@^0.5.0:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/solc/-/solc-0.5.6.tgz#13015328c61c188b96ef2c2889d73ac705195fba"
-  integrity sha512-BuvrLwOSAGEUbE4jffLBcO9Vm8OVgxImE5qFTHzjH2n+RqBHeqDDOY0gU4LvGWsA6ttjADJyRriF9Pp0vjIq2g==
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.5.7.tgz#d84697ac5cc63d9b2139bfb349cec64b64861cdc"
+  integrity sha512-DaYFzB3AAYjzPtgUl9LenPY2xjI3wG9k8U8T8YE/sXHVIoCirCY5MB6mhcFPgk/VyUtaWZPUCWiYS1E6RSiiqw==
   dependencies:
     command-exists "^1.2.8"
     fs-extra "^0.30.0"
@@ -4966,9 +4966,9 @@ ws@^3.0.0:
     ultron "~1.1.0"
 
 ws@^6.1.2:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.0.tgz#13806d9913b2a5f3cbb9ba47b563c002cbc7c526"
-  integrity sha512-deZYUNlt2O4buFCa3t5bKLf8A7FPP/TVjwOeVNpw818Ma5nk4MLXls2eoEGS39o8119QIYxTrTDoPQ5B/gTD6w==
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.1.tgz#442fdf0a47ed64f59b6a5d8ff130f4748ed524fb"
+  integrity sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
   dependencies:
     async-limiter "~1.0.0"
 


### PR DESCRIPTION
Closes #13 

This one is much scarier than the Ether contract because we call a function on a user-supplied contract. It should be fine because we have a state check before entering the relevant functions, and change the state before calling the external function. Still, worth being careful here

The final commit handles the possibility of `false` being returned from ERC20 transfers (see https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md#methods). I don’t have any unit tests for this, because we'd need to include a modified ERC20 contract.